### PR TITLE
ci: use shas for external github actions and update mavel urls

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: styfle/cancel-workflow-action@0.12.1
+      - uses: styfle/cancel-workflow-action@85880fa0301c86cca9da44039ee3bb12d3bedbfa #v0.12.1
         with:
           workflow_id: ${{ github.event.workflow.id }}
 
@@ -24,6 +24,11 @@ jobs:
     steps:
       - name: Checkout source branch
         uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew

--- a/.github/workflows/draft_new_release.yml
+++ b/.github/workflows/draft_new_release.yml
@@ -66,7 +66,7 @@ jobs:
           git push
 
       - name: Create pull request into master
-        uses: repo-sync/pull-request@v2
+        uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5 # v2
         with:
           source_branch: ${{ steps.create-release.outputs.branch_name }}
           destination_branch: 'master'

--- a/.github/workflows/manage-github-issue-for-outdated-dependencies.yml
+++ b/.github/workflows/manage-github-issue-for-outdated-dependencies.yml
@@ -12,6 +12,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+          cache: 'gradle'
+
       - name: Check outdated dependencies and create issue
         id: check-outdated-dependencies-and-create-issue
         uses: rudderlabs/github-action-updated-dependencies-notifier@main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,11 @@ jobs:
       - name: Checkout source branch
         uses: actions/checkout@v4
 
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 

--- a/.github/workflows/snapshot_release.yml
+++ b/.github/workflows/snapshot_release.yml
@@ -13,6 +13,11 @@ jobs:
       - name: Checkout source branch
         uses: actions/checkout@v4
 
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 

--- a/gradle/codecov.gradle
+++ b/gradle/codecov.gradle
@@ -29,9 +29,9 @@ task codeCoverageReport(type: JacocoReport) {
     executionData.setFrom(execData)
 
     reports {
-        xml.enabled true
-        xml.destination file("${buildDir}/reports/jacoco/report.xml")
-        html.enabled true
-        csv.enabled false
+        xml.required = true
+        xml.outputLocation = file("${buildDir}/reports/jacoco/report.xml")
+        html.required = true
+        csv.required = false
     }
 }

--- a/gradle/mvn-publish.gradle
+++ b/gradle/mvn-publish.gradle
@@ -83,6 +83,12 @@ signing {
     sign publishing.publications
 }
 
+if(POM_PACKAGING == "aar"){
+    tasks.named("signReleasePublication").configure { dependsOn("bundleReleaseAar") }
+}else{
+    tasks.named("signReleasePublication").configure { dependsOn("jar") }
+}
+
 publish.dependsOn build
 publishToMavenLocal.dependsOn build
 publishToSonatype.dependsOn publish

--- a/gradle/promote.gradle
+++ b/gradle/promote.gradle
@@ -56,8 +56,8 @@ nexusPublishing {
             username = System.getenv('NEXUS_USERNAME')
             password = System.getenv('NEXUS_PASSWORD')
 
-            nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
-            snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
         }
     }
 }


### PR DESCRIPTION
**Fixes** # (*issue*)
This pull request updates CI workflow configurations and Gradle build scripts to improve compatibility, reliability, and publishing processes. The main changes include adding Java setup steps to several GitHub Actions workflows, updating action references to use commit hashes for better reproducibility, refining Gradle reporting and signing logic, and updating Nexus repository URLs for publishing.

**CI Workflow Improvements:**

* Added `actions/setup-java@v3` to `.github/workflows/build.yml`, `.github/workflows/release.yml`, `.github/workflows/snapshot_release.yml` (Java 17), and `.github/workflows/manage-github-issue-for-outdated-dependencies.yml` (Java 11 with Gradle cache), ensuring the correct Java environment is set up for builds and dependency checks. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R28-R32) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R16-R20) [[3]](diffhunk://#diff-69397613f7f2a23faae50579930fcdb9ccda0e4c218eb7cb04a24115f9b872aeR16-R20) [[4]](diffhunk://#diff-3646b5dc038df72c96a48a8b43fb0c284c8dff792cfae00f26d550c4826caf00R15-R20)

* Updated third-party GitHub Actions (`styfle/cancel-workflow-action` and `repo-sync/pull-request`) to use specific commit hashes instead of version tags, improving workflow reproducibility and security. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L16-R16) [[2]](diffhunk://#diff-416c0e6aeb855dec6ffe340804676bcb1030d1868a6bc9a946e1264226b24edeL69-R69)

**Gradle Build and Publishing Enhancements:**

* Refined Jacoco report configuration in `gradle/codecov.gradle` to use the newer `required` and `outputLocation` properties instead of deprecated ones, aligning with Gradle best practices.

* Improved signing logic in `gradle/mvn-publish.gradle` by conditionally setting signing dependencies based on the packaging type (`aar` vs. `jar`), ensuring proper artifact signing for both Android and Java libraries.

* Updated Nexus repository URLs in `gradle/promote.gradle` to use the latest endpoints for staging and snapshots, supporting more reliable artifact publishing.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] Version upgraded (project, README, gradle, podspec etc)
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
