### PR TITLE
chore(ci): migrate draft_new_release.yml to GitHub App token [SEC-58]

### DIFF
--- a/.github/workflows/draft_new_release.yml
+++ b/.github/workflows/draft_new_release.yml
@@ -27,6 +27,7 @@ jobs:
           private-key: ${{ secrets.RELEASE_PRIVATE_KEY }}
           permission-contents: write # to create commits, tags, and releases
           permission-pull-requests: write # to create and update PRs
+          permission-members: read # to resolve team reviewers
 
       - name: Checkout source branch
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0

--- a/.github/workflows/draft_new_release.yml
+++ b/.github/workflows/draft_new_release.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   draft-new-release:
     permissions:
-      contents: write  # for Git to git push
+      contents: read  # for checkout only, App Token handles all writes
     name: Draft a new release
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/heads/feat/') || startsWith(github.ref, 'refs/heads/fix/')
@@ -19,33 +19,38 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PRIVATE_KEY }}
+          permission-contents: write # to create commits, tags, and releases
+          permission-pull-requests: write # to create and update PRs
+
       - name: Checkout source branch
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           fetch-depth: 0
+          token: ${{ steps.generate-token.outputs.token }}
 
       - name: Set Node 16
         uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: 16
 
-      # In order to make a commit, we need to initialize a user.
-      # You may choose to write something less generic here if you want, it doesn't matter functionality wise.
-      - name: Initialize mandatory git config
-        run: |
-          git config user.name "GitHub actions"
-          git config user.email noreply@github.com
-
       # Calculate the next release version based on conventional semantic release
       - name: Create release branch
         id: create-release
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           source_branch_name=${GITHUB_REF##*/}
           release_type=release
           git fetch origin master --depth=1
           git merge origin/master
           current_version=$(cat gradle.properties | grep "VERSION_NAME" | cut -d'=' -f2)
-          
+
           npm ci
           npx standard-version --skip.commit --skip.tag --skip.changelog
           new_version=$(cat gradle.properties | grep "VERSION_NAME" | cut -d'=' -f2)
@@ -58,8 +63,13 @@ jobs:
           echo "Release type is $release_type"
           echo "New version is $new_version"
           echo "New release branch name is $branch_name"
-          git checkout -b "$branch_name"
-          git push --set-upstream origin "$branch_name"
+
+          # Create branch via GitHub API
+          BASE_SHA=$(git rev-parse HEAD)
+          gh api repos/${{ github.repository }}/git/refs \
+            --method POST \
+            -f ref="refs/heads/$branch_name" \
+            -f sha="$BASE_SHA"
 
           echo "source_branch_name=$source_branch_name" >> $GITHUB_OUTPUT
           echo "branch_name=$branch_name" >> $GITHUB_OUTPUT
@@ -69,18 +79,25 @@ jobs:
         id: finish-release
         run: |
           npm ci
-          npx standard-version -a --skip.tag
+          npx standard-version --skip.commit --skip.tag
 
-      - name: Push new version in release branch
-        run: |
-          git push
+      - name: Create verified commit via API
+        uses: ryancyq/github-signed-commit@e9f3b28c80da7be66d24b8f501a5abe82a6b855f # v1.2.0
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        with:
+          branch-name: ${{ steps.create-release.outputs.branch_name }}
+          commit-message: 'chore(release): v${{ steps.create-release.outputs.new_version }}'
+          files: |
+            CHANGELOG.md
+            gradle.properties
 
       - name: Create pull request into master
         uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5 # v2
         with:
           source_branch: ${{ steps.create-release.outputs.branch_name }}
           destination_branch: 'master'
-          github_token: ${{ secrets.PAT }}
+          github_token: ${{ steps.generate-token.outputs.token }}
           pr_title: "chore(release): pulling ${{ steps.create-release.outputs.branch_name }} into master"
           pr_body:  ":crown: *An automated PR*"
           pr_reviewer: '@rudderlabs/sdk-android'


### PR DESCRIPTION
## Summary
- Migrated draft_new_release.yml from PAT to GitHub App token
- Applied new simplified pattern with signed commits via GitHub API
- Removed unnecessary git configuration and push commands

### Migration Details

| File | Changes |
|------|---------|
| draft_new_release.yml | **Removed:** git config user.name/email, git push --set-upstream, git push<br>**Added:** GitHub App token generation, branch creation via API, ryancyq/github-signed-commit action<br>**Updated:** Permissions to contents: read (App Token handles writes), standard-version with --skip.commit --skip.tag, repo-sync/pull-request to use App Token |

### Key Changes

1. **GitHub App Token Generation**: Added token generation step using actions/create-github-app-token@v2.1.4 with appropriate permissions
2. **Branch Creation via API**: Replaced `git push --set-upstream` with `gh api repos/.../git/refs` to create branch via GitHub API
3. **Signed Commits**: Using ryancyq/github-signed-commit@v1.2.0 to create verified commits via GitHub GraphQL API
4. **Simplified Commands**: Removed git config, git add, git commit, git push commands (no longer needed)

### Migration Pattern Evolution

1. The signed-commit action (`ryancyq/github-signed-commit`) creates commits via GitHub's GraphQL API, producing **verified commits** with the App's identity
2. This eliminates the need for many git commands: `git config`, `git add`, `git commit`, `git push`
3. The key insight is that branches must be created via GitHub API (`gh api .../git/refs`) before the signed-commit action can push to them

### What Was Removed

- `git config user.name` / `git config user.email` (signed-commit uses App identity)
- `git push --set-upstream origin` (branch created via API)
- `git push` (signed-commit action handles the push)
- `git add` / `git commit` (signed-commit reads files from disk and commits via API)

### What Was Added

- GitHub App token generation (early in workflow)
- Branch creation via GitHub API (`gh api repos/.../git/refs`)
- `ryancyq/github-signed-commit` action for verified commits
- `--skip.commit --skip.tag` flags for standard-version

## Test plan
- [ ] Verify workflow runs successfully on a feature branch
- [ ] Confirm commits are verified with GitHub App identity
- [ ] Verify PR is created correctly into master

🤖 Generated with [Claude Code](https://claude.com/claude-code)